### PR TITLE
Fix a bunch of small findings from the workshop

### DIFF
--- a/02-deploy-application/README.md
+++ b/02-deploy-application/README.md
@@ -31,7 +31,7 @@ Now, let's start deploying the individual services in our application. There are
 First we need to log into our Azure Container registry, so we can upload our docker images.
 
 ```sh
-az acr login --name "acr$ENV_PROJECT_NAME".azurecr.io
+az acr login --name "acr$ENV_PROJECT_NAME"
 ```
 
 ### Deploy: 🔐 Secrets into AKS
@@ -52,9 +52,8 @@ The first step is to build and push the image to the registry.
 
 ```sh
 TAG="latest"
-cd sample-application/devices-api
 
-docker build -t "acr$ENV_PROJECT_NAME.azurecr.io/devices-api":"$TAG" .
+docker build -t "acr$ENV_PROJECT_NAME.azurecr.io/devices-api":"$TAG" ./sample-application/devices-api
 docker push "acr$ENV_PROJECT_NAME.azurecr.io/devices-api":"$TAG"
 ```
 
@@ -183,9 +182,8 @@ As with our previous steps, we'll need to build the image and ensure it's pushed
 
 ```sh
 TAG="latest"
-cd sample-application/devices-state-manager/DevicesStateManager
 
-docker build -t "acr$ENV_PROJECT_NAME.azurecr.io/devices-state-manager":"$TAG" .
+docker build -t "acr$ENV_PROJECT_NAME.azurecr.io/devices-state-manager":"$TAG" ./sample-application/devices-state-manager/DevicesStateManager
 docker push "acr$ENV_PROJECT_NAME.azurecr.io/devices-state-manager":"$TAG"
 ```
 

--- a/03-add-basic-observability-instrumentation/README.md
+++ b/03-add-basic-observability-instrumentation/README.md
@@ -83,7 +83,7 @@ Here’s how to modify your Devices API `Dockerfile`:
   <summary> 🔍 Hint: step for downloading the instrumentation agent </summary>
 
   ```Docker
-  RUN curl -L -O https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.31.0/opentelemetry-javaagent.jar
+  ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.31.0/opentelemetry-javaagent.jar ./
   ```
   </details>
 
@@ -103,7 +103,7 @@ Here’s how to modify your Devices API `Dockerfile`:
 
 OpenTelemetry .NET Automatic Instrumentation injects and configures the OpenTelemetry .NET SDK into the application and adds OpenTelemetry Instrumentation to key packages and APIs used by the application.
 
-How to set it up? There are various options, we’ll focus on modifications within the `Dockerfile` for consistency reasons. An installer script is available for download and can be run as part of the `Dockerfile`. Detailed instructions can be found on GitHub: [OpenTelemetry .NET Automatic Instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation#get-started). Pay special attention to the [Instrument a container section](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation#instrument-a-container), where you’ll find an example `Dockerfile`.
+How to set it up? There are various options, we’ll focus on modifications within the `Dockerfile` for consistency reasons. An installer script is available for download and can be run as part of the `Dockerfile`. Detailed instructions can be found on GitHub: [OpenTelemetry .NET Automatic Instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation#get-started). Pay special attention to the [Instrument a container section](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation#instrument-a-container), where you’ll find an example `Dockerfile`. Make sure the installer script is run just before the application is started.
 
 Here’s what you need to do in your Devices State Manager `Dockerfile`:
 
@@ -114,7 +114,7 @@ Here’s what you need to do in your Devices State Manager `Dockerfile`:
 
   ```Docker
   ARG OTEL_VERSION=1.1.0
-  ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${OTEL_VERSION}/otel-dotnet-auto-install.sh otel-dotnet-auto-install.sh
+  ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${OTEL_VERSION}/otel-dotnet-auto-install.sh ./
   RUN apt-get update && apt-get install -y unzip && apt-get install -y curl && \
       OTEL_DOTNET_AUTO_HOME="/otel-dotnet-auto" sh otel-dotnet-auto-install.sh
   ```
@@ -139,7 +139,7 @@ WORKDIR /app
 
 RUN ./gradlew build
 
-RUN curl -L -O https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.31.0/opentelemetry-javaagent.jar
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.31.0/opentelemetry-javaagent.jar ./
 
 ENTRYPOINT ["java", "-javaagent:opentelemetry-javaagent.jar", "-jar","build/libs/devices-api.jar"]
 ```
@@ -169,7 +169,7 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 
 ARG OTEL_VERSION=1.1.0
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${OTEL_VERSION}/otel-dotnet-auto-install.sh otel-dotnet-auto-install.sh
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${OTEL_VERSION}/otel-dotnet-auto-install.sh ./
 RUN apt-get update && apt-get install -y unzip && apt-get install -y curl && \
     OTEL_DOTNET_AUTO_HOME="/otel-dotnet-auto" sh otel-dotnet-auto-install.sh
 


### PR DESCRIPTION
This small PR aims to improve the following in the Observability Workshop
- Removes `.azurecr.io` in the container registry name to avoid the warning from `az acr login`.
- Removes any need for changing directories (e.g. when running docker build). 
- Replaces `RUN curl` with `ADD` in the devices API Dockerfile to download the OTel Java agent. (`ADD` would work everywhere, even in container images where curl is absent).
- Adds a disclaimer about where the .NET OTel install script download should happen in the Dockerfile, otherwise if placed in the wrong stage of the multi-stage Dockerfile, the .NET app will crash on startup when trying to locate the OTel binaries on the expected path.